### PR TITLE
むりやり数値型にしてコンパイルエラー回避

### DIFF
--- a/src/numericOperator.ts
+++ b/src/numericOperator.ts
@@ -1,0 +1,2 @@
+const str :string = "Hello";
+console.log(+str * 123);


### PR DESCRIPTION
+を先頭につけると数値として解釈されるが、Number()変換のほうがコードがわかりやすい。