### PR TITLE
関数シグネチャのユニオン型を定義

### DIFF
--- a/src/UnionTypeFunction.ts
+++ b/src/UnionTypeFunction.ts
@@ -1,0 +1,9 @@
+type MysteryFunc = ((arg: string) => string) | ((arg: string) => number);
+
+function mysteryFunc(func: MysteryFunc) {
+  const result = func("hello");
+  console.log(result);
+}
+
+mysteryFunc((arg: string) => arg.length);
+mysteryFunc((arg: string) => arg);


### PR DESCRIPTION
呼び出しシグネチャがないstring型などを定義すると、関数呼び出しの箇所でコンパイルエラーとなる